### PR TITLE
Validate the length of the URI

### DIFF
--- a/pact/ledger.pact
+++ b/pact/ledger.pact
@@ -42,6 +42,9 @@
   ; Maximum tiemeout in days => 10 years
   (defconst MAXIMUM-TIMEOUT:decimal (days (* 10.0 365.25)))
 
+  ; Maximum URI length
+  (defconst MAXIMUM-URI-LENGTH:integer 1024)
+
   ;-----------------------------------------------------------------------------
   ; Events
   ;-----------------------------------------------------------------------------
@@ -290,9 +293,13 @@
                             policies:[module{token-policy-ng-v1}]
                             creation-guard:guard)
     @doc "Create a token with a given token-id"
-    ; First we verify that the token-id is correct, regarding the uti and the
-    ; creation gyard
+    ; First we validate the length of the URI
+    (enforce (and? (< 0) (>= MAXIMUM-URI-LENGTH) (length uri)) "URI length is invalid")
+
+    ; Then we verify that the token-id is correct, regarding the URI and the
+    ; creation guard
     (enforce-token-reserved id uri creation-guard)
+
     (let* ((_policies (sort-policies policies))
            (token-info {'id:id, 'uri:uri, 'precision:precision, 'supply:0.0})
            (call-policy (lambda (m:module{token-policy-ng-v1})

--- a/tests/test-ledger.repl
+++ b/tests/test-ledger.repl
@@ -31,6 +31,16 @@
   (create-token "t:bad" 1 "http://token-1"
                 [marmalade-ng.policy-events-A, marmalade-ng.policy-events-B] (read-keyset 'create-ks)))
 
+; Try to create with bad URI
+(expect-failure "Zero length URI" "URI length is invalid"
+                (create-token "t:r-4jQUrZWpYfEqq_iGvBn1ofgCLPoh2ZfG5kfAVX2KM" 1 ""
+                              [marmalade-ng.policy-events-A, marmalade-ng.policy-events-B] (read-keyset 'create-ks)))
+
+(expect-failure "Zero length URI" "URI length is invalid"
+                (create-token "t:r-4jQUrZWpYfEqq_iGvBn1ofgCLPoh2ZfG5kfAVX2KM" 1 (concat (make-list 1025 "a"))
+                              [marmalade-ng.policy-events-A, marmalade-ng.policy-events-B] (read-keyset 'create-ks)))
+
+
 ; Now try with evrything good
 (env-events true)
 (create-token "t:r-4jQUrZWpYfEqq_iGvBn1ofgCLPoh2ZfG5kfAVX2KM" 1 "http://token-1"


### PR DESCRIPTION
A PR for the next release. Validate the length of the URI. 
Empty URIs are not allowed anymore:  Dapp and backends should be able to rely on the fact that empty URIs don't exist.

A high limit to 1024 characters as been added in the same time. We should prevent spamming with very large strings, just in case. 