### PR TITLE
Collection meta

### DIFF
--- a/doc/source/metadata.rst
+++ b/doc/source/metadata.rst
@@ -2,7 +2,16 @@
 
 Marmalade NG Metadata
 =====================
-The URI of a token (as retrieved by :ref:`LEDGER-GET-URI`) must point to a JSON off-chain Metadata Object.
+
+General considerations
+----------------------
+
+Metadata can be attached using externals URI:
+
+* to tokens through the ledger: **Mandatory** (retrieved by :ref:`LEDGER-GET-URI`)
+* to collections through the collection policy : **Optional** (retrieved by :ref:`POLICY-COLLECTION_GET-COLLECTION`)
+
+URIs must point to a JSON off-chain Metadata Object.
 
 It is highly recommended to only store metadata (and NFTs related content like images) in reliable, immutable and long term storage.
 As such URI starting with ``https://`` or ``http://`` must be avoided. And Marketplaces should tag these NFTs as unsafe.
@@ -17,6 +26,9 @@ The 2 available options for NFT storage are either:
 **In case of IPFS, the URI must not include an `https` gateway.**: Only the raw CID prefixed by ``ipfs://`` must be present.
 
 Note that the reference implementation of Marmalade NG: (https://explorer.marmalade-ng.xyz) supports in native ipfs and kdafs.
+
+Token metadata
+--------------
 
 Specification
 ~~~~~~~~~~~~~
@@ -104,3 +116,83 @@ Example
 
 .. literalinclude:: ../../examples/metadata/meta_example.json
    :language: json
+
+
+
+.. _METADATA_COLLECTIONS:
+
+Collection metadata
+-------------------
+Specification
+~~~~~~~~~~~~~
+
+.. list-table:: JSON Metadata
+  :widths: 25 15 60
+  :header-rows: 1
+
+  * - Field Name
+    - Data Type
+    - Description
+
+  * - name
+    - string
+    - The name of the collection.
+
+  * - description
+    - string
+    - The description of the collection.
+
+  * - image
+    - string
+    - | A URI pointing to a resource with mime type image/* that represents the collection,
+      | typically displayed as a profile picture for the collection.
+
+  * - banner_image
+    - string
+    - | A URI pointing to a resource with mime type image/* that represents the collection,
+      | displayed as a banner image for the collection.
+
+  * - featured_image
+    - string
+    - | A URI pointing to a resource with mime type image/* that represents the collection,
+      | typically used for a highlight section.
+
+  * - external_link
+    - string
+    - The external link of the collection.
+
+  * - | properties
+      | *(Optional, see below)*
+    - object
+    - Arbitrary properties. Values may be strings, numbers, object or arrays.
+
+
+
+.. list-table:: JSON Metadata (properties object)
+  :widths: 25 15 60
+  :header-rows: 1
+
+  * - Field Name
+    - Data Type
+    - Description
+
+  * - | authors
+      | *(Optional)*
+    - array of objects
+    - | An array of authors who created or contributed to the asset. Each author
+      | is an object with a *name* field specifying the author's name.
+
+  * - | Other optional fields
+      | *(Optional)*
+    - Depends
+    - Any fields can be added here as required by the collection author.
+
+
+JSON Schema
+~~~~~~~~~~~
+.. literalinclude:: ../../metadata/collection-meta-schema-v1.json
+   :language: json
+
+
+Example
+~~~~~~~

--- a/doc/source/policy-collection.rst
+++ b/doc/source/policy-collection.rst
@@ -56,6 +56,18 @@ won't be diluted in a larger collection than they expect.
 The special value: ``UNLIMITED-SIZE`` (currently defined to ``0``) can be used to
 create unlimited collection.
 
+URI and Metadata
+~~~~~~~~~~~~~~~~
+It's optionally possible to attach Metadata to a collection using an URI. The URI
+must point to a JSON resource following this standard: :ref:`METADATA_COLLECTIONS`.
+
+In this case the collection has to be created using `create-collection-with-uri` instead
+of `create-collection`.
+
+If the collection has been created without an URI, or a blank URI, it's still possible
+to set up the URI
+
+
 
 Implemented hooks
 ^^^^^^^^^^^^^^^^^
@@ -114,8 +126,43 @@ If *size* is ``UNLIMITED-SIZE`` (currently defined to ``0``), the collection is 
                       "PrettyKitties" 112 "r:user.pretty-kitties-owner"
                       (keyset-ref-guard "user.pretty-kitties-owner"))
 
+
+create-collection-with-uri
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*id* ``string`` *name* ``string`` *size* ``integer`` *creator* ``string`` *creator-guard* ``guard`` *uri* ``string`` *→* ``bool``
+
+Create and register a collection with aa metadata URI.
+
+The creator guard will be enforced.
+
+*size* is the maximum number of tokens that can be contained in the collection.
+If *size* is ``UNLIMITED-SIZE`` (currently defined to ``0``), the collection is unlimited.
+
+.. code:: lisp
+
+  (use marmalade-ng.policy-collection)
+  (create-collection "c_PrettyKitties_e8XfSKUAM1fZ8HkaM1FqaYIc6v-xPUF1S2qyzz6vqQs"
+                      "PrettyKitties" 112 "r:user.pretty-kitties-owner"
+                      (keyset-ref-guard "user.pretty-kitties-owner"
+                      "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi" ))
+
+
+set-uri
+~~~~~~~
+*id* ``string`` *uri* ``string`` *→* ``bool``
+
+Set the URI if it was not previously supplied.
+
+.. code:: lisp
+
+  (use marmalade-ng.policy-collection)
+  (set-uri "c_PrettyKitties_e8XfSKUAM1fZ8HkaM1FqaYIc6v-xPUF1S2qyzz6vqQs"
+           "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+
 View functions
 ^^^^^^^^^^^^^^
+.. _POLICY-COLLECTION_GET-COLLECTION:
+
 get-collection
 ~~~~~~~~~~~~~~
 *collection-id* ``string`` *→* ``object{collection-sch}``
@@ -135,7 +182,8 @@ Get collection details from a collection-id.
    "id": "c_Cats_ZMLLJuSq0JoHSR4f_ZgUa2H_p7Rr71CN8CjQ7ZL_hU0",
    "max-size": 0,
    "name": "Cats",
-   "size": 3
+   "size": 3,
+   "uri":""
   }
 
 .. _POLICY-COLLECTION-GET-TOKEN-COLLECTION:
@@ -159,7 +207,8 @@ Get collection details of a token.
    "id": "c_Cats_ZMLLJuSq0JoHSR4f_ZgUa2H_p7Rr71CN8CjQ7ZL_hU0",
    "max-size": 0,
    "name": "Cats",
-   "size": 3
+   "size": 3,
+   "uri": ""
   }
 
 get-all-collections
@@ -196,7 +245,8 @@ Return the list of all collection objects owned by a creator.
      "id": "c_Cats_ZMLLJuSq0JoHSR4f_ZgUa2H_p7Rr71CN8CjQ7ZL_hU0",
      "max-size": 0,
      "name": "Cats",
-     "size": 3
+     "size": 3,
+     "uri": ""
     },
     {"creator": "k:1caa4f5f12ea490f8f020734ed08be1926f290855818e19abfaf6dc8d03ce798",
      "creator-guard": KeySet {keys: ["1caa4f5f12ea490f8f020734ed08be1926f290855818e19abfaf6dc8d03ce798"],
@@ -204,7 +254,8 @@ Return the list of all collection objects owned by a creator.
      "id": "c_WildCats_G_X53tGkoawB8WDvJdTvlMG_VWmHeYZVieS-n5DUi9U",
      "max-size": 0,
      "name": "WildCats",
-     "size": 3
+     "size": 3,
+     "uri": "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
     }]
 
 
@@ -269,9 +320,20 @@ CREATE-COLLECTION
 
 Emitted when a collection is created.
 
+COLLECTION-URI
+~~~~~~~~~~~~~~
+*uri* ``string``
+
+Emitted when the URI of collection is set.
 
 ADD-TO-COLLECTION
 ~~~~~~~~~~~~~~~~~
 *collection-id* ``string`` *token-id* ``string``
 
 Emitted when a token is added to a collection.
+
+UPDATE-COLLECTION
+~~~~~~~~~~~~~~~~~
+*collection-id* ``string``
+
+Update collection data. Currently only the URI can only be updated if it hasn't be set before.

--- a/metadata/collection-meta-schema-v1.json
+++ b/metadata/collection-meta-schema-v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://marmalade-ng/collection-meta-schema-v1.json",
+  "title": "Marmalade NG Collection Metadata",
+  "description": "Schema for Marmalade-NG collection Metadata",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the collection."
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the collection."
+    },
+    "family": {
+      "type": "string",
+      "description": "Specifying the larger category or group to which the collection belongs"
+    },
+    "image": {
+      "type": "string",
+      "format": "uri",
+      "description": "A URI pointing to a resource with mime type image/* that represents the collection, typically displayed as a profile picture for the collection."
+    },
+    "banner_image": {
+      "type": "string",
+      "format": "uri",
+      "description": "A URI pointing to a resource with mime type image/* that represents the collection, displayed as a banner image for the collection."
+    },
+    "featured_image": {
+      "type": "string",
+      "format": "uri",
+      "description": "A URI pointing to a resource with mime type image/* that represents the featured image for the collection, typically used for a highlight section."
+    },
+    "external_link": {
+      "type": "string",
+      "format": "uri",
+      "description": "The external link of the collection."
+    },
+    "properties": {
+      "type": "object",
+      "description": "Arbitrary properties. Values may be strings, numbers, object or arrays",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "An array of authors who created or contributed to the asset.",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The author's name."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/tests/test-policy-collection.repl
+++ b/tests/test-policy-collection.repl
@@ -14,7 +14,8 @@
 
 (env-data {'dogs-ks:["dogs-owner-key"],
            'cats-ks:["cats-owner-key"],
-           'pigs-ks:["pigs-owner-key"]})
+           'pigs-ks:["pigs-owner-key"],
+           'rabbits-ks:["rabbits-owner-key"]})
 
 ; Create a defined keysit to test Pigs
 (namespace "user")
@@ -32,6 +33,9 @@
 
 (print (+ "BigPigs Collection ID: => "
           (create-collection-id "BigsPigs" (keyset-ref-guard "user.PigsLover"))))
+
+(print (+ "Rabbits Collection ID: => "
+          (create-collection-id "Rabbits" (read-keyset 'rabbits-ks))))
 
 ; try to create without signature
 (expect-failure "No keys" "Keyset failure"
@@ -78,6 +82,16 @@
 (create-collection "c_SmallPigs_OpMyaBMEuVD9flzeMZ7gHNk2xEH3HU8yDGib4w3S5gs" "SmallPigs" UNLIMITED-SIZE "r:user.PigsLover" (keyset-ref-guard "user.PigsLover"))
 
 (create-collection "c_BigsPigs_lZnDio-8EqbWxznH2r0v7q1iB_QRjfSWFrBp9Xj-Prc" "BigsPigs" UNLIMITED-SIZE "r:user.PigsLover" (keyset-ref-guard "user.PigsLover"))
+
+
+
+; Create with URI with Rabbits collection
+(env-sigs [{'key:"rabbits-owner-key", 'caps:[]}])
+(env-events true)
+(create-collection-with-uri "c_Rabbits_7ipiEeThCviYd9BFKo6gZwfW4XR-mLdDHHPicjl4x9Y" "Rabbits" UNLIMITED-SIZE "RabbitsLover"  (read-keyset 'rabbits-ks)
+                            "https://rabbits-online.net/rabbits.json")
+(ev-analyzer.store (env-events true))
+(expect "Event COLLECTION-URI" true (ev-analyzer.is-present "COLLECTION-URI"))
 
 (commit-tx)
 
@@ -169,6 +183,7 @@
 (expect-that "Get all collections" (compose (sort) (= ["c_BigsPigs_lZnDio-8EqbWxznH2r0v7q1iB_QRjfSWFrBp9Xj-Prc",
                                                        "c_Cats_ZMLLJuSq0JoHSR4f_ZgUa2H_p7Rr71CN8CjQ7ZL_hU0",
                                                        "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY",
+                                                       "c_Rabbits_7ipiEeThCviYd9BFKo6gZwfW4XR-mLdDHHPicjl4x9Y",
                                                        "c_SmallPigs_OpMyaBMEuVD9flzeMZ7gHNk2xEH3HU8yDGib4w3S5gs"]))
              (get-all-collections))
 
@@ -207,3 +222,43 @@
 (expect "cat1 is rank 1" 1 (get-token-rank-in-collection "t:8UUtZdQJTomKPposMzgKLIyr-kXzwVRbUiRnk6ll1GQ"))
 (expect "cat2 is rank 1" 2 (get-token-rank-in-collection "t:FiEymgltFYwVdXtWJsVlYp_7h7eg6t6fzwqLjZv1_lM"))
 (expect "cat3 is rank 1" 3 (get-token-rank-in-collection "t:MkWmoRRFNCDhqPRn7XQ1U0CVuJ01Sb8XAXfrS7H47OI"))
+(commit-tx)
+
+
+; Test Collections URIs
+(begin-tx)
+(use marmalade-ng.policy-collection)
+
+; First check some URIs
+; Dogs has no URI
+(expect-that "No URI for dogs" (compose (at 'uri) (= "")) (get-collection "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY"))
+; But Rabbits has an uri
+(expect-that "An URI for rabbits" (compose (at 'uri) (= "https://rabbits-online.net/rabbits.json")) (get-collection "c_Rabbits_7ipiEeThCviYd9BFKo6gZwfW4XR-mLdDHHPicjl4x9Y"))
+
+; Try to change the URI of dogs without signature
+(expect-failure "Without signature" "Keyset failure"
+  (set-uri "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY"  "https://dogs-online.net/dogs.json"))
+
+; With signture
+(env-sigs [{'key:"dogs-owner-key", 'caps:[(UPDATE-COLLECTION "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY")]}])
+
+(env-events true)
+(set-uri "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY"  "https://dogs-online.net/dogs.json")
+(ev-analyzer.store (env-events true))
+(expect "Event COLLECTION-URI" true (ev-analyzer.is-present "COLLECTION-URI"))
+
+
+; Now Dogs has an URI
+(expect-that "No URI for dogs" (compose (at 'uri) (= "https://dogs-online.net/dogs.json")) (get-collection "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY"))
+
+; Try to change it again
+(env-sigs [{'key:"dogs-owner-key", 'caps:[(UPDATE-COLLECTION "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY")]}])
+(expect-failure "Immutable URI" "Collection URI is immutable"
+  (set-uri "c_Dogs_8BRJPRYtqM-2w8ASMYq6Toq4PIvhws-kHh0nbYfT1iY"  "https://new-dogs-online.net/new-dogs.json"))
+
+; Try to change Rabbits
+(env-sigs [{'key:"rabbits-owner-key", 'caps:[(UPDATE-COLLECTION "c_Rabbits_7ipiEeThCviYd9BFKo6gZwfW4XR-mLdDHHPicjl4x9Y")]}])
+(expect-failure "Immutable URI" "Collection URI is immutable"
+  (set-uri "c_Rabbits_7ipiEeThCviYd9BFKo6gZwfW4XR-mLdDHHPicjl4x9Y"  "https://new-rabbits-online.net/new-rabbits.json"))
+
+  (commit-tx)


### PR DESCRIPTION
The idea behind this PR is to attach meta information to a collection. The metadata is a JSON file referenced by a URI attached to the collection. Once defined, this URI is immutable.

This idea is currently being discussed for Ethereum too:
https://eips.ethereum.org/EIPS/eip-7572

Attaching a URI to a collection is still optional. The new version of the collection policy is backward compatible:

The function `(create-collection)`, and event `(CREATE-COLLECTION)` keep the same signatures.

Two new functions are added:
- `(create-collection-with-uri)` : **id** ``string`` **name** ``string`` **size** ``integer`` **creator** ``string`` **creator-guard** ``guard`` **uri** ``string`` :  Create a new collection with an URI.
- `(set-uri)` : **id** ``string`` **uri** ``string`` : Add a URI to a previously created collection without URI. Can only be used once.

Once the URI is set with one of the two functions, **the URI is immutable and can't be changed.**

A new event is added:

-  `(COLLECTION-URI)`: **uri** ``string``: Emitted when a URI is added to a collection. When  `(create-collection-with-uri)`  is used, both events `(CREATE-COLLECTION)` and  `(COLLECTION-URI)` are emitted.

Included the JSON schema based on ERC-7572.

Since the DB schema is updated, the collection policy won't bless the previous one. And a migration transaction (signed by the governance) will be required.

